### PR TITLE
Also enable wlan on qualcomm and mediatek devices without boot_wlan

### DIFF
--- a/debian/droidian-quirks-device.droidian-boot-wlan.service
+++ b/debian/droidian-quirks-device.droidian-boot-wlan.service
@@ -1,9 +1,10 @@
 [Unit]
-Description=Enables WLAN on devices with boot_wlan
-Before=lxc@android.service
-Requires=android-mount.service
-After=android-mount.service
-ConditionPathExists=/sys/kernel/boot_wlan/boot_wlan
+Description=Enables WLAN on boot
+Requires=lxc@android.service
+After=lxc@android.service
+ConditionPathExists=|/sys/kernel/boot_wlan/boot_wlan
+ConditionPathExists=|/dev/wlan
+ConditionPathExists=|/dev/wmtWifi
 
 [Service]
 Type=oneshot

--- a/device/droidian-boot-wlan.sh
+++ b/device/droidian-boot-wlan.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
-echo 1 > /sys/kernel/boot_wlan/boot_wlan
+[ -e /sys/kernel/boot_wlan/boot_wlan ] && echo 1 > /sys/kernel/boot_wlan/boot_wlan
+
+[ -e /dev/wlan ] && echo ON > /dev/wlan
+
+[ -e /dev/wmtWifi ] && echo 1 > /dev/wmtWifi
 
 exit 0


### PR DESCRIPTION
From stats collected from both droidian and ut groups.

 `/dev/wlan` is used by recent qualcomm devices and `/dev/wmtWifi` for mediatek devices.