### PR TITLE
Some kernels might not have the enable_lmk parameter

### DIFF
--- a/device/droidian-lmk-disable.sh
+++ b/device/droidian-lmk-disable.sh
@@ -3,7 +3,7 @@
 # Disable lowmemorykiller for now
 #
 
-echo 0 > /sys/module/lowmemorykiller/parameters/enable_lmk
-echo 0 > /sys/module/lowmemorykiller/parameters/enable_adaptive_lmk
+[ -e /sys/module/lowmemorykiller/parameters/enable_lmk ] echo 0 > /sys/module/lowmemorykiller/parameters/enable_lmk
+[ -e /sys/module/lowmemorykiller/parameters/enable_adaptive_lmk ] && echo 0 > /sys/module/lowmemorykiller/parameters/enable_adaptive_lmk
 
 exit 0


### PR DESCRIPTION
Some devices might not have the module param `enable_lmk`, for those the lmk needs to be tweaked from the `minfree`, disabled from the kernel or it can also be [easily patched](https://nekobin.com/yeminebuce)?

Also there's a check for adaptive lmk which might not exist at all on some kernel. 

Reference https://gitlab.com/ubports/porting/community-ports/android10/xiaomi-redmi-9c/kernel-xiaomi-mt6765/-/blob/halium10-new/drivers/staging/android/lowmemorykiller.c