### PR TITLE
scripts: hostname: Set hostname from device codename

### DIFF
--- a/hostname/script/hostname
+++ b/hostname/script/hostname
@@ -11,7 +11,7 @@ ANDROID_VENDOR_PROPS="/vendor/build.prop"
 if [ -e "${PREFERRED_HOSTNAME_FILE}" ]; then
 	new_hostname="$(cat ${PREFERRED_HOSTNAME_FILE})"
 elif [ -e "${ANDROID_VENDOR_PROPS}" ]; then
-	new_hostname="$(grep ro.product.vendor.model= ${ANDROID_VENDOR_PROPS} | cut -d'=' -f2)"
+	new_hostname="$(grep ro.product.vendor.device= ${ANDROID_VENDOR_PROPS} | cut -d'=' -f2)"
 fi
 
 [ -n "${new_hostname}" ] || exit 1


### PR DESCRIPTION
The hostname doesn't support spaces, so `hostnamectl hostname ${new_hostname}` fails with too many arguments. Also in case of long device names, it will cut it in the `Device Name` section in `About`, so for example `Redmi Note 9 Pro` gets cut to `Redmi Note`