### PR TITLE
[droidian-quirks-hybris-gl] Add libglesshadercache.so to LD_PRELOAD

### DIFF
--- a/debian/droidian-quirks-hybris-gl.install
+++ b/debian/droidian-quirks-hybris-gl.install
@@ -1,1 +1,2 @@
 hybris-gl/zz-droidian.sh /etc/profile.d
+hybris-gl/zz-gles-shader-cache.sh /etc/profile.d

--- a/hybris-gl/zz-gles-shader-cache.sh
+++ b/hybris-gl/zz-gles-shader-cache.sh
@@ -1,0 +1,17 @@
+LIBRARY="libglesshadercache.so"
+
+case "${LD_PRELOAD}" in
+	*${LIBRARY}*)
+		# Already there
+		return 0
+		;;
+	"")
+		;;
+	*)
+		LIBRARY="${LIBRARY}:"
+		;;
+esac
+
+if [ "${UID}" != "0" ]; then
+	export LD_PRELOAD="${LIBRARY}${LD_PRELOAD}"
+fi


### PR DESCRIPTION
When available, preloading this library cuts GTK4 app startup time in half or less.

Depends on droidian/halium-wrappers#1