### PR TITLE
d/droidian-quirks-keyring.prerm: fix typo

### DIFF
--- a/debian/droidian-quirks-keyring.prerm
+++ b/debian/droidian-quirks-keyring.prerm
@@ -23,6 +23,6 @@ configure() {
 
 case "$1" in
 	"remove")
-		remove
+		configure
 		;;
 esac


### PR DESCRIPTION
When removing, call function configure not remove.

`remove` does not exist which leads uninstalling to fail: `/var/lib/dpkg/info/droidian-quirks-keyring.prerm: 26: remove: not found`