### PR TITLE
droidian-quirks-waydroid: Add support for a shared folder

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -158,6 +158,7 @@ Description: Various quirks and Droidian-specific settings for firefox
 
 Package: droidian-quirks-waydroid
 Architecture: all
+Depends: bindfs
 Description: Various quirks for the Droidian flavour of Waydroid
  This package provides various quriks for the Droidian flavour
  of Waydroid.

--- a/debian/droidian-quirks-waydroid.dirs
+++ b/debian/droidian-quirks-waydroid.dirs
@@ -1,1 +1,4 @@
 /etc/apt/preferences.d
+/usr/lib/systemd/user
+/usr/share/polkit-1/rules.d
+/usr/bin

--- a/debian/droidian-quirks-waydroid.install
+++ b/debian/droidian-quirks-waydroid.install
@@ -1,1 +1,5 @@
 waydroid/apt/preferences.d/waydroid-system /etc/apt/preferences.d
+waydroid/systemd/waydroid-mount-shared-folders.service /usr/lib/systemd/user
+waydroid/bin/waydroid-mount-shared /usr/bin
+waydroid/bin/waydroid-umount-shared /usr/bin
+waydroid/polkit/91-waydroid.rules /usr/share/polkit-1/rules.d

--- a/waydroid/bin/waydroid-mount-shared
+++ b/waydroid/bin/waydroid-mount-shared
@@ -1,0 +1,17 @@
+#!/bin/pkexec /bin/bash
+# vim: expandtab ft=bash
+
+set -Eeuo pipefail
+
+USERNAME=$(id -un ${PKEXEC_UID})
+GROUP=$(id -gn ${PKEXEC_UID})
+
+waydroid_mount() {
+    /usr/bin/bindfs -u ${USERNAME} -g ${GROUP} -p 770 -o nonempty $@
+}
+
+mkdir -p /home/${USERNAME}/Waydroid /home/${USERNAME}/.local/share/waydroid/data/media/0/Droidian
+chown ${USERNAME}: /home/${USERNAME}/Waydroid
+chown 1023:android_media_rw /home/${USERNAME}/.local/share/waydroid/data/media/0/Droidian
+
+waydroid_mount /home/${USERNAME}/.local/share/waydroid/data/media/0/Droidian /home/${USERNAME}/Waydroid

--- a/waydroid/bin/waydroid-umount-shared
+++ b/waydroid/bin/waydroid-umount-shared
@@ -1,0 +1,8 @@
+#!/bin/pkexec /bin/bash
+# vim: expandtab ft=bash
+
+set -Eeuo pipefail
+
+USERNAME=$(id -un ${PKEXEC_UID})
+
+umount /home/${USERNAME}/Waydroid

--- a/waydroid/polkit/91-waydroid.rules
+++ b/waydroid/polkit/91-waydroid.rules
@@ -1,0 +1,8 @@
+polkit.addRule(function(action, subject) {
+    if (action.id == "org.freedesktop.policykit.exec" &&
+        action.lookup("program") == "/bin/bash") {
+        if (action.lookup("command_line").match("^/bin/bash /usr/bin/waydroid-(mount|umount)-shared$")) {
+            return polkit.Result.YES;
+        }
+    }
+});

--- a/waydroid/systemd/waydroid-mount-shared-folders.service
+++ b/waydroid/systemd/waydroid-mount-shared-folders.service
@@ -1,0 +1,12 @@
+[Unit]
+Description = Mount Waydroid shared folder
+ConditionPathExists = %h/.config/Droidian/waydroid_shared_folder
+
+[Service]
+Type=oneshot
+ExecStart = /usr/bin/waydroid-mount-shared
+RemainAfterExit=yes
+ExecStop = /usr/bin/waydroid-umount-shared
+
+[Install]
+WantedBy = default.target


### PR DESCRIPTION
We are not using Waydroid way of sharing folders for two reasons:
- With kernel bind, permissions are forced by Android on startup leaving user folders ro in Droidian
- With bindfs mount inside Android (forced uid/gid and perms), Android just ignore folders

So here we use bindfs to mount a Droidian folder (inside Waydroid) to a Waydroid folder (inside Droidian). Bindfs allows to convert uid/gid from 1023:android_media_rw to droidian:droidian.

If ~/.config/Droidian/waydroid_shared_folder exists, a systemd user service mount the shared folder

This will allow us to enable/disable shared folder support from GNOME Control Center.