### PR TITLE
droidian-quirks-plamo-wf: add quirks for plasma-mobile-wf

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -161,6 +161,11 @@ Description: Various quirks for the Droidian flavour of Waydroid
  This package provides various quriks for the Droidian flavour
  of Waydroid.
 
+Package: droidian-quirks-plamo-wf
+Architecture: all
+Depends: plasma-mobile-wf-config-hwcomposer
+Description: Quirk to install necessary env vars for plasma-mobile-wf.
+
 Package: droidian-quirks-api28
 Architecture: all
 Depends: libgbinder

--- a/debian/droidian-quirks-plamo-wf.dirs
+++ b/debian/droidian-quirks-plamo-wf.dirs
@@ -1,0 +1,1 @@
+/etc/profile.d/

--- a/debian/droidian-quirks-plamo-wf.install
+++ b/debian/droidian-quirks-plamo-wf.install
@@ -1,0 +1,1 @@
+plamo-wf/zz-plamo-wf.sh /etc/profile.d/

--- a/plamo-wf/zz-plamo-wf.sh
+++ b/plamo-wf/zz-plamo-wf.sh
@@ -1,0 +1,18 @@
+# needed for correct plasma theming and 
+# exporting vars globally to make things work over ssh
+
+# set by droidian-gnome-quirks
+# override with plasma vars
+export XDG_CURRENT_DESKTOP=KDE
+unset XDG_SESSION_DESKTOP
+export XDG_MENU_PREFIX=plasma-
+unset QT_STYLE_OVERRIDE
+export GSK_RENDERER=gl
+
+# ssh
+export WAYLAND_DISPLAY=wayland-0
+export QT_QPA_PLATFORMTHEME=KDE
+export QT_QUICK_CONTROLS_STYLE=org.kde.breeze
+export QT_QUICK_CONTROLS_MOBILE=true
+export PLASMA_INTEGRATION_USE_PORTAL=1
+export PLASMA_PLATFORM=phone:handset


### PR DESCRIPTION
@arpio23 @g7 

@g7 is GSK_RENDERER even needed ? then we can conflict gnome quirks too and there is option to override it too thats how its currently done

for now I made the quirk depend on plasma hwc config pkg since it will remove it and make it easy to switch to phosh for users
also I think it can be done other way around not really sure what to do ...

draft until decision on depend is resolved and arpio patch wayfire to launch with wayland-0 socket 
