### PR TITLE
[droidian-quirks-firefox*] Switch to software WebGL by default

### DIFF
--- a/firefox-gpu/zzz_hybris-webrender.js
+++ b/firefox-gpu/zzz_hybris-webrender.js
@@ -18,3 +18,7 @@ pref("layers.acceleration.disabled", false);
 pref('layers.acceleration.force-enabled', true);
 pref('layers.gpu-process.enabled', true);
 pref('layers.gpu-process.force-enabled', true);
+
+// enable hw WebGL
+pref("webgl.forbid-hardware", false);
+pref("webgl.forbid-software", true);

--- a/firefox/hybris-gpu.js
+++ b/firefox/hybris-gpu.js
@@ -4,3 +4,6 @@
 // This option will break firefox esr 115 on devices with a Mali gpu
 // on other devices it doesn't do anything anyways firefox is not gpu accelerated
 pref("layers.acceleration.disabled", true);
+// Similarly on Mali GPUs at least hw WebGL crashes whole browser on YT/about:support etc
+pref("webgl.forbid-hardware", true);
+pref("webgl.forbid-software", false);


### PR DESCRIPTION
Sandbox/seccomp appear to block `libhybris` from loading `libGLESv2.so` etc which is problematic to the point of bringing down the whole browser upon navigating to YouTube or `about:support` for example on Mali GPUs as seen on at least MediaTek Helio G99 (MT6789) devices.